### PR TITLE
optimize run instructions to save space

### DIFF
--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -3,20 +3,20 @@ ENV HEP_OSLIBS_VER 1.1.4-1.el6
 LABEL maintainer="Alessandro.DeSalvo@roma1.infn.it"
 
 # HEP OSlibs
-RUN yum -y install epel-release
-RUN yum -y install http://linuxsoft.cern.ch/wlcg/sl6/x86_64/HEP_OSlibs_SL6-${HEP_OSLIBS_VER}.x86_64.rpm
+RUN yum -y install epel-release && \
+    yum -y install http://linuxsoft.cern.ch/wlcg/sl6/x86_64/HEP_OSlibs_SL6-${HEP_OSLIBS_VER}.x86_64.rpm && \
+    #
+    # Final update and creation of the package list
+    yum -y update && \
+    rpm -qa > /var/lib/package-list && \
+    #
+    # Remove unuseful stuff
+    rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
-# Final update and creation of the package list
-RUN yum -y update
-RUN rpm -qa > /var/lib/package-list
-
-# Remove unuseful stuff
-RUN rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
 # Timestamp
-RUN /bin/sh -c 'TS=`date +%Y%m%d%H%M%S`; echo $TS > /docker-creation-date'
-RUN /bin/sh -c 'echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh'
-RUN /bin/sh -c 'echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh'
-
-# Create site dirs
-RUN mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb
+RUN echo `date +%Y%m%d%H%M%S` > /docker-creation-date && \
+    echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh && \
+    echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh && \
+    # Create site dirs
+    mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -3,20 +3,19 @@ ENV HEP_OSLIBS_VER 7.2.5-1.el7.cern
 LABEL maintainer="Alessandro.DeSalvo@roma1.infn.it"
 
 # HEP OSLibs
-RUN yum -y install epel-release
-RUN yum -y install http://linuxsoft.cern.ch/wlcg/centos7/x86_64/HEP_OSlibs-${HEP_OSLIBS_VER}.x86_64.rpm
-
-# Final update and creation of the package list
-RUN yum -y update
-RUN rpm -qa > /var/lib/package-list
-
-# Remove unuseful stuff
-RUN rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
+RUN yum -y install epel-release && \
+    yum -y install http://linuxsoft.cern.ch/wlcg/centos7/x86_64/HEP_OSlibs-${HEP_OSLIBS_VER}.x86_64.rpm && \
+    #
+    # Final update and creation of the package list
+    yum -y update && \
+    rpm -qa > /var/lib/package-list && \
+    #
+    # Remove unuseful stuff
+    rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
 # Timestamp
-RUN /bin/sh -c 'TS=`date +%Y%m%d%H%M%S`; echo $TS > /docker-creation-date'
-RUN /bin/sh -c 'echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh'
-RUN /bin/sh -c 'echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh'
-
-# Create site dirs
-RUN mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb
+RUN echo `date +%Y%m%d%H%M%S` > /docker-creation-date && \
+    echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh && \
+    echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh && \
+    # Create site dirs
+    mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb

--- a/slc/5/Dockerfile
+++ b/slc/5/Dockerfile
@@ -3,19 +3,17 @@ ENV HEP_OSLIBS_VER 1.0.3-0
 LABEL maintainer="Alessandro.DeSalvo@roma1.infn.it"
 
 # HEP OSLibs
-RUN yum -y install http://linuxsoft.cern.ch/wlcg/sl5/x86_64/HEP_OSlibs_SL5-${HEP_OSLIBS_VER}.x86_64.rpm
+RUN yum -y install http://linuxsoft.cern.ch/wlcg/sl5/x86_64/HEP_OSlibs_SL5-${HEP_OSLIBS_VER}.x86_64.rpm && \
+    # Final update and creation of the package list
+    yum -y update  && \
+    rpm -qa > /var/lib/package-list && \
+    # Remove unuseful stuff
+    rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
-# Final update and creation of the package list
-RUN yum -y update
-RUN rpm -qa > /var/lib/package-list
-
-# Remove unuseful stuff
-RUN rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
 # Timestamp
-RUN /bin/sh -c 'TS=`date +%Y%m%d%H%M%S`; echo $TS > /docker-creation-date'
-RUN /bin/sh -c 'echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh'
-RUN /bin/sh -c 'echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh'
-
-# Create site dirs
-RUN mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /atlashome /srv /alrb
+RUN echo `date +%Y%m%d%H%M%S` > /docker-creation-date && \
+    echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh && \
+    echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh && \
+    # Create site dirs
+    mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /atlashome /srv /alrb

--- a/slc/6/Dockerfile
+++ b/slc/6/Dockerfile
@@ -3,19 +3,18 @@ ENV HEP_OSLIBS_VER 1.1.4-1.el6
 LABEL maintainer="Alessandro.DeSalvo@roma1.infn.it"
 
 # Additional packages
-RUN yum -y install http://linuxsoft.cern.ch/wlcg/sl6/x86_64/HEP_OSlibs_SL6-${HEP_OSLIBS_VER}.x86_64.rpm
-
-# Final update and creation of the package list
-RUN yum -y update
-RUN rpm -qa > /var/lib/package-list
-
-# Remove unuseful stuff
-RUN rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
+RUN yum -y install http://linuxsoft.cern.ch/wlcg/sl6/x86_64/HEP_OSlibs_SL6-${HEP_OSLIBS_VER}.x86_64.rpm && \
+  #
+  # Final update and creation of the package list
+  yum -y update && \
+  rpm -qa > /var/lib/package-list && \
+  #
+  # Remove unuseful stuff
+  rm -fr /var/lib/yum/* /var/cache/yum/* /usr/share/doc/* /boot/*
 
 # Timestamp
-RUN /bin/sh -c 'TS=`date +%Y%m%d%H%M%S`; echo $TS > /docker-creation-date'
-RUN /bin/sh -c 'echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh'
-RUN /bin/sh -c 'echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh'
-
-# Create site dirs
-RUN mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb
+RUN echo `date +%Y%m%d%H%M%S` > /docker-creation-date && \
+    echo "export CDATE_DOCKER=\"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.sh && \
+    echo "setenv CDATE_DOCKER \"`cat /docker-creation-date`\"" > /etc/profile.d/container-date.csh && \
+    # Create site dirs
+    mkdir -p /scratch /gpfs/work /gpfs/scratch /cvmfs /etc/grid-security/certificates /var/lib/condor /srv /alrb


### PR DESCRIPTION
Hi @desalvo,

this PR optimizes some of the `RUN` instructions that result in the image being roughly 40% smaller in compressed size by combining a couple of layers. (the way docker works having `rm` in a new `RUN` instructions actually does not save space)

https://hub.docker.com/r/lukasheinrich/atlas-grid-slc6-base/tags/
https://hub.docker.com/r/atlasadc/atlas-grid-slc6-base/tags/

untarred it's an even large savings:

```
/Users/lukas/Code/containers_on_grid/atlas-grid-docker-base > docker images|grep atlas-grid-slc6-base
lukasheinrich/atlas-grid-slc6-base                       latest              22ecf650060a        9 minutes ago       763MB
atlasadc/atlas-grid-slc6-base                            latest              d449305cdda1        6 weeks ago         1.66GB
```
the instructions themselves stay exactly the same.

if this looks good to you, I am happy to optimize the other images as well in a similar way.

